### PR TITLE
v0.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "anaconda-packaging-utils" %}
-{% set version = "v0.1.2" %}
+{% set version = "v0.1.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/anaconda-distribution/anaconda-packaging-utils/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 963ca4627b8887bfe831c0f1eecbb057c24532a51d3c565de5282cd825e5da6f
+  sha256: 131d0c96752b6bf79d9b47ffcc77b50a0e40ee94df24ea21e81aedf437ddb8c6
 
 build:
   number: 0


### PR DESCRIPTION
Minor bump, just changing the version and SHA to fix a bug in consuming the Python type stubs.